### PR TITLE
Introduce geometry_msgs to package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -52,6 +52,7 @@
   <build_depend>rospy</build_depend>
   <build_export_depend>rospy</build_export_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <exec_depend>rospy</exec_depend>
 


### PR DESCRIPTION
This PR introduces `geometry_msgs` to be a dependency of the package.